### PR TITLE
Don't rush bash in interactive mode

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -1,4 +1,4 @@
-#!/bin/bash -ie
+#!/bin/bash -e
 
 main() {
   local env=()


### PR DESCRIPTION
Running bash in interactive mode causes this module to fail for me. I'm not exactly sure why it fails, but I don't see why Bash needs the `-i` flag.
