### PR TITLE
Change the output directory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,12 +14,12 @@ variable "environment" {
 
 resource "null_resource" "runner" {
   triggers {
-    filepath = "${path.cwd}/tmp/${md5(concat(var.package, var.version, var.environment))}.zip"
+    filepath = "${path.cwd}/.terraform/npm-lambda-packer/${md5(concat(var.package, var.version, var.environment))}.zip"
   }
 
   provisioner "local-exec" {
     command = <<COMMAND
-mkdir -p ${path.cwd}/tmp
+mkdir -p "$(dirname "${null_resource.runner.triggers.filepath}")"
 ${path.module}/bin/package ${join(" ", formatlist("-e \"%s\"", compact(split("\n", var.environment))))} -o ${null_resource.runner.triggers.filepath} ${var.package}@${var.version}
 COMMAND
   }


### PR DESCRIPTION
Changes the output directory from `${path.cwd}/tmp` to `${path.cwd}/.terraform/npm-lambda-directory`. This means that users of this module don't need to add custom `tmp/` paths to their `.gitignore` file.
