### PR TITLE
Fix installation of NPM packages from GitHub

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -22,10 +22,15 @@ main() {
     shift # past argument or value
   done
 
-  local package="$1"
-  local name="${package%@*}"
+  local package="${1/%@*/}"
+  local name=$(basename "${package%@*}")
   local base=$(mktemp -d)
   local workdir="${base}/${name}-package"
+
+  # Installing a package from GitHub works a bit differently.
+  if [[ "${package}" =~ / ]]; then
+    package="${package/@/#}"
+  fi
 
   if [ -z "$output" ]; then
     output="$name.zip"

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "null_resource" "runner" {
   provisioner "local-exec" {
     command = <<COMMAND
 mkdir -p ${path.cwd}/tmp
-${path.module}/bin/package ${join(" ", formatlist("-e \"%s\"", compact(split("\n", var.environment))))} -o ${null_resource.runner.triggers.filepath} ${var.package}@${var.version}
+${path.module}/bin/package ${join(" ", formatlist("-e \"%s\"", compact(split("\n", var.environment))))} -o "${null_resource.runner.triggers.filepath}" "${var.package}@${var.version}"
 COMMAND
   }
 }


### PR DESCRIPTION
Currently it is not possible to specify a Git URL as an argument to the `package` parameter. Whilst investigating this issue I discovered that the logic surrounding the temporary and working directories can be tidied up anyway, which solves my original problem. Specifically, I don't believe that there is any need to create a subdirectory underneath the directory created my `mktemp -d`.

```
exit status 1. Output: mkdir: cannot create directory ‘/tmp/tmp.xJyhxzsxXM/git+https://git@github.com/REDACTED.git-package’: No such file or directory
```

I also had to change the way that versions are specified in order to accomodate the `${PACKAGE}#${VERSION}` notation that is used when installing packages via `git`.
